### PR TITLE
Fixed behavior for larger images

### DIFF
--- a/src/Panel.jsx
+++ b/src/Panel.jsx
@@ -30,6 +30,8 @@ const Iframe = styled.iframe({
 const Img = styled.img({
     border: '0 none',
     objectFit: 'contain',
+    max-width: 100%;
+    max-height: 100%;
 });
 
 const Toolbar = styled.div({


### PR DESCRIPTION
Without max-width/height, larger images will simply overflow the ghost element and will not be resizable.